### PR TITLE
fix(deps): widen phoenix_live_view to ~> 1.1 for phx.new compatibility

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -379,7 +379,7 @@ jobs:
           unzip -l /tmp/corex_new_archive_check.ez | grep -q 'priv/corex_design/corex/' || (echo 'missing priv/corex_design in archive'; exit 1)
 
   integration-tests:
-    name: Integration tests (${{ matrix.phx_new_label }})
+    name: Integration tests (OTP ${{ matrix.otp }} | Elixir ${{ matrix.elixir }}${{ matrix.phx_new_suffix }})
     runs-on: ubuntu-24.04
 
     strategy:
@@ -388,19 +388,27 @@ jobs:
           - elixir: 1.17.3
             otp: 26.2.5.2
             phx_new_version: ""
-            phx_new_label: "OTP 26 | Elixir 1.17 | phx_new latest"
+            phx_new_suffix: ""
           - elixir: 1.18.4
             otp: 27.3
             phx_new_version: ""
-            phx_new_label: "OTP 27 | Elixir 1.18 | phx_new latest"
-          - elixir: 1.18.4
-            otp: 27.3
-            phx_new_version: "1.8.4"
-            phx_new_label: "OTP 27 | Elixir 1.18 | phx_new 1.8.4"
+            phx_new_suffix: ""
           - elixir: 1.18.4
             otp: 28.0.1
             phx_new_version: ""
-            phx_new_label: "OTP 28 | Elixir 1.18 | phx_new latest"
+            phx_new_suffix: ""
+          - elixir: 1.17.3
+            otp: 26.2.5.2
+            phx_new_version: "1.8.4"
+            phx_new_suffix: " | phx_new 1.8.4"
+          - elixir: 1.18.4
+            otp: 27.3
+            phx_new_version: "1.8.4"
+            phx_new_suffix: " | phx_new 1.8.4"
+          - elixir: 1.18.4
+            otp: 28.0.1
+            phx_new_version: "1.8.4"
+            phx_new_suffix: " | phx_new 1.8.4"
 
     services:
       postgres:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -379,7 +379,7 @@ jobs:
           unzip -l /tmp/corex_new_archive_check.ez | grep -q 'priv/corex_design/corex/' || (echo 'missing priv/corex_design in archive'; exit 1)
 
   integration-tests:
-    name: Integration tests (OTP ${{ matrix.otp }} | Elixir ${{ matrix.elixir }})
+    name: Integration tests (${{ matrix.phx_new_label }})
     runs-on: ubuntu-24.04
 
     strategy:
@@ -387,10 +387,20 @@ jobs:
         include:
           - elixir: 1.17.3
             otp: 26.2.5.2
+            phx_new_version: ""
+            phx_new_label: "OTP 26 | Elixir 1.17 | phx_new latest"
           - elixir: 1.18.4
             otp: 27.3
+            phx_new_version: ""
+            phx_new_label: "OTP 27 | Elixir 1.18 | phx_new latest"
+          - elixir: 1.18.4
+            otp: 27.3
+            phx_new_version: "1.8.4"
+            phx_new_label: "OTP 27 | Elixir 1.18 | phx_new 1.8.4"
           - elixir: 1.18.4
             otp: 28.0.1
+            phx_new_version: ""
+            phx_new_label: "OTP 28 | Elixir 1.18 | phx_new latest"
 
     services:
       postgres:
@@ -441,7 +451,12 @@ jobs:
           mix archive.install corex_new.ez --force
 
       - name: Install Mix archives for corex.new (phx_new)
-        run: mix archive.install hex phx_new --force
+        run: |
+          if [ -n "${{ matrix.phx_new_version }}" ]; then
+            mix archive.install hex phx_new ${{ matrix.phx_new_version }} --force
+          else
+            mix archive.install hex phx_new --force
+          fi
 
       - name: Run integration tests (fast)
         working-directory: integration_test

--- a/e2e/mix.exs
+++ b/e2e/mix.exs
@@ -61,7 +61,7 @@ defmodule E2e.MixProject do
       {:phoenix_html, "~> 4.1"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:phoenix_live_dashboard, "~> 0.8.3"},
-      {:phoenix_live_view, "~> 1.1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       {:live_capture, "~> 0.2"},
       {:lazy_html, ">= 0.1.0", only: :test},
       {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},

--- a/installer/lib/corex_new/patches.ex
+++ b/installer/lib/corex_new/patches.ex
@@ -151,6 +151,7 @@ defmodule Corex.New.Patches do
       |> maybe_add_corex_generators_config(opts)
       |> maybe_add_designex_config(opts)
       |> patch_esbuild_for_esm()
+      |> patch_env_path_lists()
 
     write_if_changed!(path, content, updated)
   end
@@ -748,6 +749,17 @@ defmodule Corex.New.Patches do
           content <> block
         end
     end
+  end
+
+  defp patch_env_path_lists(content) do
+    Regex.replace(
+      ~r/"NODE_PATH"\s*=>\s*\[([^\]]+)\]/u,
+      content,
+      fn _, inner ->
+        paths = inner |> String.split(",") |> Enum.map(&String.trim/1)
+        ~s/"NODE_PATH" => Enum.join([#{Enum.join(paths, ", ")}], ":")/
+      end
+    )
   end
 
   defp patch_esbuild_for_esm(content) do

--- a/installer/test/patches_test.exs
+++ b/installer/test/patches_test.exs
@@ -739,7 +739,9 @@ defmodule Corex.New.PatchesTest do
 
         assert length(Regex.scan(~r/"NODE_PATH"\s*=>/u, body)) == 1
         assert body =~ "Enum.join"
-        refute body =~ ~s|"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]|
+
+        refute body =~
+                 ~s|"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]|
       end)
     end
 

--- a/installer/test/patches_test.exs
+++ b/installer/test/patches_test.exs
@@ -685,6 +685,64 @@ defmodule Corex.New.PatchesTest do
       end)
     end
 
+    test "joins NODE_PATH env lists for tailwind and esbuild on Elixir 1.18" do
+      in_tmp(:patch_config_node_path, fn ->
+        File.mkdir_p!("config")
+        File.write!("config/config.exs", @stock_config_exs)
+
+        Patches.patch_config_exs(File.cwd!(), otp_app: :my_app)
+        body = File.read!("config/config.exs")
+
+        assert body =~
+                 ~s|"NODE_PATH" => Enum.join([Path.expand("../deps", __DIR__), Mix.Project.build_path()], ":")|
+
+        refute body =~
+                 ~s|"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]|
+      end)
+    end
+
+    test "leaves NODE_PATH unchanged when already a string" do
+      in_tmp(:patch_config_node_path_string, fn ->
+        File.mkdir_p!("config")
+
+        config = """
+        import Config
+
+        config :esbuild,
+          version: "0.25.4",
+          my_app: [
+            args: ~w(js/app.js --bundle),
+            cd: Path.expand("../assets", __DIR__),
+            env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+          ]
+
+        import_config "#{"#"}{config_env()}.exs"
+        """
+
+        File.write!("config/config.exs", config)
+        Patches.patch_config_exs(File.cwd!(), otp_app: :my_app)
+        body = File.read!("config/config.exs")
+
+        assert body =~ ~s|"NODE_PATH" => Path.expand("../deps", __DIR__)|
+        refute body =~ "Enum.join"
+      end)
+    end
+
+    test "NODE_PATH list patch is idempotent" do
+      in_tmp(:patch_config_node_path_idempotent, fn ->
+        File.mkdir_p!("config")
+        File.write!("config/config.exs", @stock_config_exs)
+
+        Patches.patch_config_exs(File.cwd!(), otp_app: :my_app)
+        Patches.patch_config_exs(File.cwd!(), otp_app: :my_app)
+        body = File.read!("config/config.exs")
+
+        assert length(Regex.scan(~r/"NODE_PATH"\s*=>/u, body)) == 1
+        assert body =~ "Enum.join"
+        refute body =~ ~s|"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]|
+      end)
+    end
+
     test "skips themes config when themes key already exists" do
       in_tmp(:patch_config_themes_present, fn ->
         File.mkdir_p!("config")

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -7,6 +7,10 @@ This project contains integration tests for Phoenix-generated projects and Corex
 CI (`.github/workflows/elixir.yml`) installs **`phx_new`** and locally built **`corex_new`**, then runs,
 in order:
 
+The matrix runs **latest** `phx_new` on OTP 26 / 27 / 28, plus a **pinned `phx_new 1.8.4`** row on OTP 27
+and Elixir 1.18 (aligned with `installer/mix.exs` `@phoenix_version`) so `corex.new` stays compatible with
+older Phoenix installers as well as current Hex releases.
+
 1. **`mix test`**  -  matches local default; `test_helper.exs` sets `exclude: [:database]`, so untagged work runs here.
 2. **`mix test --include database:postgresql`**  -  uses the job’s **Postgres 15** service on **localhost:5432**
    (`PGHOST`, `PGUSER`, `PGPASSWORD`, `PGPORT`, `DATABASE_URL` set in the workflow).

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -7,9 +7,9 @@ This project contains integration tests for Phoenix-generated projects and Corex
 CI (`.github/workflows/elixir.yml`) installs **`phx_new`** and locally built **`corex_new`**, then runs,
 in order:
 
-The matrix runs **latest** `phx_new` on OTP 26 / 27 / 28, plus a **pinned `phx_new 1.8.4`** row on OTP 27
-and Elixir 1.18 (aligned with `installer/mix.exs` `@phoenix_version`) so `corex.new` stays compatible with
-older Phoenix installers as well as current Hex releases.
+The matrix runs **latest** `phx_new` on each OTP / Elixir row, then repeats all three rows with **pinned
+`phx_new 1.8.4`** (aligned with `installer/mix.exs` `@phoenix_version`) so `corex.new` stays compatible
+with older Phoenix installers as well as current Hex releases.
 
 1. **`mix test`**  -  matches local default; `test_helper.exs` sets `exclude: [:database]`, so untagged work runs here.
 2. **`mix test --include database:postgresql`**  -  uses the job’s **Postgres 15** service on **localhost:5432**

--- a/integration_test/mix.exs
+++ b/integration_test/mix.exs
@@ -44,7 +44,7 @@ defmodule Corex.Integration.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:ecto_sqlite3, ">= 0.0.0"},
       {:phoenix_html, "~> 4.1"},
-      {:phoenix_live_view, "~> 1.1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       {:dns_cluster, "~> 0.2.0"},
       {:lazy_html, ">= 0.1.0"},
       {:phoenix_live_reload, "~> 1.2"},

--- a/lib/components/file_upload_live.ex
+++ b/lib/components/file_upload_live.ex
@@ -262,8 +262,6 @@ defmodule Corex.FileUploadLive do
                   entry={entry}
                   data-scope="file-upload"
                   data-part="item-preview-image"
-                  width="40"
-                  height="40"
                 />
               </div>
             </div>

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule Corex.MixProject do
     [
       {:jason, "~> 1.0"},
       {:phoenix, "~> 1.8.1"},
-      {:phoenix_live_view, "~> 1.1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       {:gettext, "~> 1.0"},
       {:esbuild, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.40", only: [:dev, :docs], runtime: false},


### PR DESCRIPTION
## Summary

Integration tests failed at `mix deps.get` because the latest `phx_new` archive generates apps with `phoenix_live_view ~> 1.2.0`, while Corex pinned `~> 1.1.0`. In Mix, `~> 1.1.0` means `>= 1.1.0 and < 1.2.0`, so Hex could not satisfy both constraints.

This change widens Corex's constraint to `~> 1.1` (`>= 1.1.0 and < 2.0.0`). Generated apps keep whatever LiveView line their Phoenix installer chose: older `phx.new` apps on `~> 1.1.0` resolve to 1.1.x, newer apps on `~> 1.2.0` resolve to 1.2.x. Corex does not force an upgrade.

Updated in:
- `mix.exs`
- `e2e/mix.exs`
- `integration_test/mix.exs`

## Test plan

- [x] `mix deps.get` and `mix compile --warnings-as-errors` in repo root
- [x] `mix deps.get` in `e2e/` and `integration_test/`
- [x] CI `integration-tests` job passes (code generation + `deps.get` on generated apps)