### PR TITLE
fix(packaging): keep Dialyzer PLTs out of Hex priv

### DIFF
--- a/design/mix.exs
+++ b/design/mix.exs
@@ -55,8 +55,8 @@ defmodule CorexDesign.MixProject do
 
   defp dialyzer do
     [
-      plt_local_path: "priv/plts",
-      plt_core_path: "priv/plts",
+      plt_local_path: "_build/plts",
+      plt_core_path: "_build/plts",
       plt_add_apps: [:mix, :ex_unit],
       flags: [:error_handling, :extra_return, :missing_return, :unmatched_returns]
     ]
@@ -101,7 +101,7 @@ defmodule CorexDesign.MixProject do
         "GitHub" => @scm_url,
         "Website" => "https://corex.gigalixirapp.com/en"
       },
-      files: ~w(lib priv mix.exs README.md CHANGELOG.md LICENSE .formatter.exs guides)
+      files: ~w(lib priv/css mix.exs README.md CHANGELOG.md LICENSE .formatter.exs guides)
     ]
   end
 

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -73,8 +73,8 @@ defmodule Corex.New.MixProject do
 
   defp dialyzer do
     [
-      plt_local_path: "priv/plts",
-      plt_core_path: "priv/plts",
+      plt_local_path: "_build/plts",
+      plt_core_path: "_build/plts",
       plt_add_apps: [:mix, :ex_unit],
       flags: [:error_handling, :extra_return, :missing_return, :unmatched_returns]
     ]

--- a/mcp/mix.exs
+++ b/mcp/mix.exs
@@ -57,8 +57,8 @@ defmodule CorexMcp.MixProject do
 
   defp dialyzer do
     [
-      plt_local_path: "priv/plts",
-      plt_core_path: "priv/plts",
+      plt_local_path: "_build/plts",
+      plt_core_path: "_build/plts",
       plt_add_apps: [:mix, :ex_unit],
       flags: [:error_handling, :extra_return, :missing_return, :unmatched_returns]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -84,8 +84,8 @@ defmodule Corex.MixProject do
 
   defp dialyzer do
     [
-      plt_local_path: "priv/plts",
-      plt_core_path: "priv/plts",
+      plt_local_path: "_build/plts",
+      plt_core_path: "_build/plts",
       plt_add_apps: [:mix, :ex_unit, :phoenix, :phoenix_live_view],
       flags: [:error_handling, :extra_return, :missing_return, :unmatched_returns],
       ignore_warnings: ".dialyzer_ignore.exs"


### PR DESCRIPTION
## Summary
- Move Dialyzer PLT paths from `priv/plts` to `_build/plts` in `corex`, `corex_design`, `corex_mcp`, and `corex_new` so caches are not written under packaged `priv`.
- Narrow the `corex_design` Hex package `files` list to `priv/css` so Dialyzer artifacts cannot be included even if they appear under `priv`.

## Test plan
- [x] `cd design && mix hex.build` — listing includes `priv/css/...`, no `priv/plts`
- [x] Confirm local `mix dialyzer` writes under `_build/plts` (covered by existing `_build/` gitignore)
- [x] Abort any in-progress `mix hex.publish` that listed `priv/plts` and republish from this branch if needed