### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 ## Unreleased
 
-### Design CSS pipeline
+## 0.2.2 - 2026-08-29
+
+### Upgrade notes
 
 - Design CSS is an **asset build step** only (`mix corex.design.build` on `assets.build` / `assets.deploy`). The optional `Mix.Tasks.Compile.CorexDesign` compiler is removed; do not add `:corex_design` to `compilers`.
 - `mix corex.new` / `mix corex.tableau.new` add `{:corex_design, "~> 0.2", runtime: false}` in every Mix env (no `only: :dev`) so `MIX_ENV=prod mix assets.deploy` can run the Mix task.
 - After changing `config :corex_design`, re-run `mix corex.design.build` (or `mix assets.build`). `mix compile` does not regenerate Design CSS.
-- `--a11y` plugs call `Corex.Design.Accessibility` (cookie → `data-*`); they do not rebuild CSS. `runtime: false` means Design is not started as an OTP app. Apps that use `mix release` with `--a11y` must add `corex_design: :load` so Mix.Release keeps those BEAMs.
+- `--a11y` plugs call `Corex.Design.Accessibility` (cookie → `data-*`); they do not rebuild CSS. `runtime: false` means Design is not started as an OTP app. Apps that use `mix release` with `--a11y` must add `corex_design: :load` so Mix.Release keeps those BEAMs. `mix corex.new --a11y` / `mix corex.tableau.new --a11y` print this as a follow-up step.
+
+### Bug fixes
+
+- Slider and angle-slider thumbs emit `aria-valuemin` / `aria-valuemax` / `aria-valuenow` in SSR (Zag still owns them after hydrate).
+- Doc a11y waits for descendant `[data-loading]` so async pattern skeletons are gone before axe runs.
+- [dev] `mix assets.build` raises a clear error when the nested `design/` Mix project fails (fetch `cd design && mix deps.get`) instead of a `MatchError`.
+- Hexdocs for `:corex` now include this changelog.
 
 ### Security
 
 - [e2e, integration_test] Bump `postgrex` to **0.22.4** ([CVE-2026-66838](https://osv.dev/vulnerability/EEF-CVE-2026-66838) / [GHSA-3gww-3f36-2388](https://github.com/elixir-ecto/ecto/security/advisories/GHSA-3gww-3f36-2388): SQL injection via the `:comment` option on `Postgrex.stream/4`).
-- Slider thumbs emit `aria-valuemin` / `aria-valuemax` / `aria-valuenow` in SSR (Zag still owns them after hydrate). Doc a11y waits for descendant `[data-loading]` so async pattern skeletons are gone before axe runs.
 
 ## 0.2.1 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,28 @@
 # Changelog
 
-## Unreleased
-
 ## 0.2.2 - 2026-08-29
 
 ### Upgrade notes
 
-- Design CSS is an **asset build step** only (`mix corex.design.build` on `assets.build` / `assets.deploy`). The optional `Mix.Tasks.Compile.CorexDesign` compiler is removed; do not add `:corex_design` to `compilers`.
-- `mix corex.new` / `mix corex.tableau.new` add `{:corex_design, "~> 0.2", runtime: false}` in every Mix env (no `only: :dev`) so `MIX_ENV=prod mix assets.deploy` can run the Mix task.
-- After changing `config :corex_design`, re-run `mix corex.design.build` (or `mix assets.build`). `mix compile` does not regenerate Design CSS.
-- `--a11y` plugs call `Corex.Design.Accessibility` (cookie → `data-*`); they do not rebuild CSS. `runtime: false` means Design is not started as an OTP app. Apps that use `mix release` with `--a11y` must add `corex_design: :load` so Mix.Release keeps those BEAMs. `mix corex.new --a11y` / `mix corex.tableau.new --a11y` print this as a follow-up step.
+- Remove `:corex_design` from `compilers` if present. Run `mix corex.design.build` from `assets.build` / `assets.deploy`.
+- Keep `{:corex_design, "~> 0.2", runtime: false}` (no `only: :dev`).
+- After changing `config :corex_design`, run `mix corex.design.build` (or `mix assets.build`).
+- For `--a11y` + `mix release`, add `corex_design: :load`.
+
+### Components
+
+- **Slider** — single thumb (`value={n}`) or range / N thumbs (`value={[a, b]}`) ([#106](https://github.com/corex-ui/corex/pull/106)).
 
 ### Bug fixes
 
-- Slider and angle-slider thumbs emit `aria-valuemin` / `aria-valuemax` / `aria-valuenow` in SSR (Zag still owns them after hydrate).
+- Slider and angle-slider thumbs emit `aria-valuemin` / `aria-valuemax` / `aria-valuenow` in SSR.
 - Doc a11y waits for descendant `[data-loading]` so async pattern skeletons are gone before axe runs.
 - [dev] `mix assets.build` raises a clear error when the nested `design/` Mix project fails (fetch `cd design && mix deps.get`) instead of a `MatchError`.
 - Hexdocs for `:corex` now include this changelog.
+
+### Dependencies
+
+- Zag.js **1.43.3**, Phoenix **1.8.13**, LiveView **1.2.10**, Credo / `oeditus_credo` updates ([#118](https://github.com/corex-ui/corex/pull/118)).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Design and MCP ship as separate Hex packages. Theming is config-driven through a
 
 ### Security
 
-- Strip leading C0/space before URL scheme checks in `Corex.Url` and the JS redirect helper so prefixed `javascript:` / `data:` cannot bypass allowlists (same class as LiveView CVE-2026-58228). See [SECURITY.md](SECURITY.md).
+- Strip leading C0/space before URL scheme checks in the URL allowlist helper and the JS redirect helper so prefixed `javascript:` / `data:` cannot bypass allowlists (same class as LiveView CVE-2026-58228). See [SECURITY.md](https://github.com/corex-ui/corex/blob/main/SECURITY.md).
 - Require Phoenix LiveView **≥ 1.2.7** and Phoenix **≥ 1.8.9** for upstream link/navigation fixes.
 
 ### Design

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,14 @@ For large features (new components, API changes), open an issue first so we can 
 git clone https://github.com/corex-ui/corex.git
 cd corex
 mix deps.get
+(cd design && mix deps.get)
 npm install
 mix assets.build
 mix test
 npm run check
 ```
+
+`mix assets.build` ends by shelling into `design/` (`mix corex.design.build`) to refresh the `--no-design` CSS snapshot. That project has its own Mix deps; skip `cd design && mix deps.get` and the nested Mix run fails.
 
 ### Test coverage
 

--- a/design/CHANGELOG.md
+++ b/design/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Changelog
 
-## Unreleased
-
 ## 0.2.2 - 2026-08-29
 
 ### Upgrade notes
 
-Design CSS is generated only by `mix corex.design.build` (Phoenix `assets.build` /
-`assets.deploy`). The `Mix.Tasks.Compile.CorexDesign` compiler is removed.
-`Corex.Design.Accessibility` is an allowlist helper (cookie → `data-*`), not a
-CSS generator. `mix release` apps that call it should list `corex_design: :load`.
+- Run `mix corex.design.build` from `assets.build` / `assets.deploy` (not `mix compile`).
+- For `--a11y` + `mix release`, add `corex_design: :load`.
 
 See the monorepo
 [CHANGELOG](https://github.com/corex-ui/corex/blob/main/CHANGELOG.md).

--- a/design/CHANGELOG.md
+++ b/design/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.2.2 - 2026-08-29
+
+### Upgrade notes
+
 Design CSS is generated only by `mix corex.design.build` (Phoenix `assets.build` /
 `assets.deploy`). The `Mix.Tasks.Compile.CorexDesign` compiler is removed.
 `Corex.Design.Accessibility` is an allowlist helper (cookie → `data-*`), not a

--- a/design/mix.exs
+++ b/design/mix.exs
@@ -1,7 +1,7 @@
 defmodule CorexDesign.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @scm_url "https://github.com/corex-ui/corex"
 
   def project do

--- a/guides/update.md
+++ b/guides/update.md
@@ -26,7 +26,7 @@ mix corex.design.build
 
 Or run a full asset build with `mix assets.build`. After changing `config :corex_design`, re-run that Mix task; `mix compile` does not regenerate Design CSS.
 
-For day-to-day patch notes, see [CHANGELOG.md](https://github.com/corex-ui/corex/blob/main/CHANGELOG.md). The rest of this guide is the **0.1.x → 0.2.0** migration.
+For day-to-day patch notes, see the [changelog](changelog.html). The rest of this guide is the **0.1.x → 0.2.0** migration.
 
 ## Upgrading to 0.2.0
 

--- a/installer/CHANGELOG.md
+++ b/installer/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## 0.2.2 - 2026-08-29
+
+### Upgrade notes
+
 `mix corex.new` / `mix corex.tableau.new` no longer inject `:corex_design` into
 `compilers`. Design CSS is rebuilt from `assets.build` / `assets.deploy` via
 `mix corex.design.build`. The `corex_design` dep is `runtime: false` in every
 Mix env (no `only: :dev`). `--a11y` apps that use `mix release` should add
-`corex_design: :load` so Mix.Release keeps Accessibility helper BEAMs.
+`corex_design: :load` so Mix.Release keeps Accessibility helper BEAMs; the
+generators print that follow-up when `--a11y` is on.
 
 See the monorepo
 [CHANGELOG](https://github.com/corex-ui/corex/blob/main/CHANGELOG.md).

--- a/installer/CHANGELOG.md
+++ b/installer/CHANGELOG.md
@@ -1,17 +1,12 @@
 # Changelog
 
-## Unreleased
-
 ## 0.2.2 - 2026-08-29
 
 ### Upgrade notes
 
-`mix corex.new` / `mix corex.tableau.new` no longer inject `:corex_design` into
-`compilers`. Design CSS is rebuilt from `assets.build` / `assets.deploy` via
-`mix corex.design.build`. The `corex_design` dep is `runtime: false` in every
-Mix env (no `only: :dev`). `--a11y` apps that use `mix release` should add
-`corex_design: :load` so Mix.Release keeps Accessibility helper BEAMs; the
-generators print that follow-up when `--a11y` is on.
+- Do not add `:corex_design` to `compilers`. Run `mix corex.design.build` from `assets.build` / `assets.deploy`.
+- Keep `{:corex_design, "~> 0.2", runtime: false}` (no `only: :dev`).
+- For `--a11y` + `mix release`, add `corex_design: :load` (printed as a follow-up step).
 
 See the monorepo
 [CHANGELOG](https://github.com/corex-ui/corex/blob/main/CHANGELOG.md).

--- a/installer/lib/corex_new/post_generate.ex
+++ b/installer/lib/corex_new/post_generate.ex
@@ -140,12 +140,23 @@ defmodule Corex.New.PostGenerate do
         "#{indent}$ iex -S mix phx.server\n"
       ])
 
+    a11y_block =
+      if Keyword.get(opts, :a11y, false) do
+        IO.iodata_to_binary([
+          "\nIf you ship with mix release, add corex_design: :load so Mix.Release keeps ",
+          "Accessibility helper BEAMs (runtime: false apps are omitted otherwise).\n"
+        ])
+      else
+        ""
+      end
+
     IO.iodata_to_binary([
       initial,
       database_block,
       assets_block,
       localize_block,
-      server_block
+      server_block,
+      a11y_block
     ])
   end
 

--- a/installer/lib/corex_new/tableau/post_generate.ex
+++ b/installer/lib/corex_new/tableau/post_generate.ex
@@ -84,7 +84,17 @@ defmodule Corex.New.Tableau.PostGenerate do
         "#{indent}$ mix build\n"
       ])
 
-    IO.iodata_to_binary([initial, assets_block, server_block])
+    a11y_block =
+      if Keyword.get(opts, :a11y, false) do
+        IO.iodata_to_binary([
+          "\nIf you ship with mix release, add corex_design: :load so Mix.Release keeps ",
+          "Accessibility helper BEAMs (runtime: false apps are omitted otherwise).\n"
+        ])
+      else
+        ""
+      end
+
+    IO.iodata_to_binary([initial, assets_block, server_block, a11y_block])
   end
 
   defp git_available? do

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -6,7 +6,7 @@ end
 defmodule Corex.New.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @phoenix_version "1.8.7"
   @scm_url "https://github.com/corex-ui/corex"
 

--- a/installer/test/post_generate_test.exs
+++ b/installer/test/post_generate_test.exs
@@ -144,6 +144,33 @@ defmodule Corex.New.PostGenerateTest do
         assert output =~ "mix localize.download_locales"
       end)
     end
+
+    test "prints mix release corex_design: :load hint when a11y is true" do
+      in_tmp(:prompt_a11y, fn ->
+        PostGenerate.prompt_install(File.cwd!(), File.cwd!(),
+          install: false,
+          ecto: false,
+          lang: false,
+          a11y: true
+        )
+
+        output = shell_info_text()
+        assert output =~ "corex_design: :load"
+      end)
+    end
+
+    test "omits mix release hint when a11y is false" do
+      in_tmp(:prompt_no_a11y, fn ->
+        PostGenerate.prompt_install(File.cwd!(), File.cwd!(),
+          install: false,
+          ecto: false,
+          lang: false
+        )
+
+        output = shell_info_text()
+        refute output =~ "corex_design: :load"
+      end)
+    end
   end
 
   defp shell_info_text(timeout \\ 50) do

--- a/installer/test/tableau/post_generate_test.exs
+++ b/installer/test/tableau/post_generate_test.exs
@@ -79,6 +79,24 @@ defmodule Corex.New.Tableau.PostGenerateTest do
       end)
     end
 
+    test "prints mix release corex_design: :load hint when a11y is true" do
+      in_tmp("tableau prompt a11y", fn ->
+        PostGenerate.prompt_install(File.cwd!(), install: false, design: true, a11y: true)
+
+        output = shell_info_text()
+        assert output =~ "corex_design: :load"
+      end)
+    end
+
+    test "omits mix release hint when a11y is false" do
+      in_tmp("tableau prompt no a11y", fn ->
+        PostGenerate.prompt_install(File.cwd!(), install: false, design: true)
+
+        output = shell_info_text()
+        refute output =~ "corex_design: :load"
+      end)
+    end
+
     test "prompts for install when the option is omitted" do
       in_tmp("tableau prompt lazy", fn ->
         send(self(), {:mix_shell_input, :yes?, false})

--- a/lib/components/angle_slider.ex
+++ b/lib/components/angle_slider.ex
@@ -367,7 +367,7 @@ defmodule Corex.AngleSlider do
           {Connect.mounted_control(%Control{id: @id, dir: @dir, disabled: @disabled, read_only: @read_only, invalid: @invalid, orientation: @orientation})}
         >
           <div
-            {Connect.mounted_thumb(%Thumb{id: @id, dir: @dir, disabled: @disabled, read_only: @read_only, invalid: @invalid, orientation: @orientation})}
+            {Connect.mounted_thumb(%Thumb{id: @id, dir: @dir, value: @value, disabled: @disabled, read_only: @read_only, invalid: @invalid, orientation: @orientation})}
             title="Thumb"
             />
           <div
@@ -492,6 +492,7 @@ defmodule Corex.AngleSlider do
       %Thumb{
         id: assigns.ctx.id,
         dir: assigns.ctx.dir,
+        value: assigns.ctx.value,
         orientation: assigns.ctx.orientation,
         disabled: assigns.ctx.disabled,
         read_only: assigns.ctx.read_only,

--- a/lib/components/angle_slider/anatomy.ex
+++ b/lib/components/angle_slider/anatomy.ex
@@ -172,6 +172,7 @@ defmodule Corex.AngleSlider.Anatomy do
     defstruct [
       :id,
       :dir,
+      :value,
       orientation: "horizontal",
       disabled: false,
       read_only: false,
@@ -181,6 +182,7 @@ defmodule Corex.AngleSlider.Anatomy do
     @type t :: %__MODULE__{
             id: String.t(),
             dir: String.t(),
+            value: number() | nil,
             orientation: String.t(),
             disabled: boolean(),
             read_only: boolean(),

--- a/lib/components/angle_slider/connect.ex
+++ b/lib/components/angle_slider/connect.ex
@@ -180,16 +180,23 @@ defmodule Corex.AngleSlider.Connect do
 
   @spec thumb(Thumb.t()) :: map()
   def thumb(assigns) do
+    value = effective_angle_value(Map.get(assigns, :value))
+
     %{
       "data-scope" => "angle-slider",
       "data-part" => "thumb",
       "id" => "angle-slider:#{assigns.id}:thumb",
       "dir" => assigns.dir,
       "style" => "rotate:var(--angle);",
+      "role" => "slider",
+      "aria-valuemin" => "0",
+      "aria-valuemax" => "360",
+      "aria-valuenow" => format_number(value),
       "data-disabled" => presence_attr(assigns.disabled),
       "data-invalid" => presence_attr(assigns.invalid),
       "data-readonly" => presence_attr(assigns.read_only)
     }
+    |> maybe_put("tabindex", if(assigns.disabled in [nil, false], do: "0"))
   end
 
   def ignore_thumb(assigns) do

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.2.2 - 2026-08-29
+
+### Enhancements
+
 Host-app install snippets recommend `{:corex_design, "~> 0.2", runtime: false}`
 without `only: :dev`, matching the asset-pipeline Mix task. `design_guide`
 accessibility notes that preference CSS is a design build (not per request)

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Changelog
 
-## Unreleased
-
 ## 0.2.2 - 2026-08-29
 
-### Enhancements
+### Upgrade notes
 
-Host-app install snippets recommend `{:corex_design, "~> 0.2", runtime: false}`
-without `only: :dev`, matching the asset-pipeline Mix task. `design_guide`
-accessibility notes that preference CSS is a design build (not per request)
-and that `mix release` needs `corex_design: :load`.
+- Install snippets use `{:corex_design, "~> 0.2", runtime: false}` (no `only: :dev`).
+- For `--a11y` + `mix release`, add `corex_design: :load`.
 
 See the monorepo
 [CHANGELOG](https://github.com/corex-ui/corex/blob/main/CHANGELOG.md).

--- a/mcp/mix.exs
+++ b/mcp/mix.exs
@@ -1,7 +1,7 @@
 defmodule CorexMcp.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @scm_url "https://github.com/corex-ui/corex"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Corex.MixProject do
     end
   end
 
-  @version "0.2.1"
+  @version "0.2.2"
   @elixir_requirement "~> 1.17"
 
   def project do
@@ -192,7 +192,7 @@ defmodule Corex.MixProject do
 
     Mix.shell().info("Building --no-design Corex CSS snapshot (neo/light)…")
 
-    {_, 0} =
+    {_stream, exit_code} =
       System.cmd(
         "mix",
         [
@@ -206,6 +206,16 @@ defmodule Corex.MixProject do
         into: IO.stream(:stdio, :line),
         stderr_to_stdout: true
       )
+
+    if exit_code != 0 do
+      Mix.raise("""
+      Failed to build --no-design Corex CSS snapshot (exit #{exit_code}).
+
+      The nested Mix project lives in design/. Fetch its deps first:
+
+          cd design && mix deps.get
+      """)
+    end
 
     Mix.shell().info("Synced no-design export → installer/priv/static/corex")
     :ok
@@ -242,6 +252,7 @@ defmodule Corex.MixProject do
       source_ref: "v#{@version}",
       assets: %{"docs/images" => "images"},
       extras: [
+        "CHANGELOG.md",
         "guides/installation.md",
         "guides/manual_installation.md",
         "guides/design.md",
@@ -272,6 +283,7 @@ defmodule Corex.MixProject do
       groups_for_extras: [
         {:Introduction,
          [
+           "CHANGELOG.md",
            "guides/installation.md",
            "guides/manual_installation.md",
            "guides/design.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corex",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The official JavaScript client for the Corex Phoenix Hooks.",
   "license": "MIT",
   "module": "./priv/static/corex.mjs",

--- a/test/components/angle_slider_test.exs
+++ b/test/components/angle_slider_test.exs
@@ -19,6 +19,10 @@ defmodule Corex.AngleSliderTest do
       assert html =~ ~r/data-part="root"/
       assert html =~ ~r/data-part="control"/
       assert html =~ ~r/data-part="thumb"/
+      assert html =~ ~S(role="slider")
+      assert html =~ ~S(aria-valuemin="0")
+      assert html =~ ~S(aria-valuemax="360")
+      assert html =~ ~S(aria-valuenow="0")
       assert html =~ ~r/data-part="hidden-input"/
       assert html =~ ~r/data-part="value-text"/
     end
@@ -199,9 +203,14 @@ defmodule Corex.AngleSliderTest do
       assert c["data-part"] == "control"
       assert c["id"] == "angle-slider:x:control"
 
-      t = Connect.thumb(base)
+      t = Connect.thumb(Map.merge(base, %{value: 45}))
       assert t["data-part"] == "thumb"
       assert t["id"] == "angle-slider:x:thumb"
+      assert t["role"] == "slider"
+      assert t["aria-valuemin"] == "0"
+      assert t["aria-valuemax"] == "360"
+      assert t["aria-valuenow"] == "45"
+      assert t["tabindex"] == "0"
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lockstep **0.2.2** for the published packages (`corex`, `corex_design`, `corex_mcp`, `corex_new` / npm `corex`).

Changelogs dated **2026-08-29** (no empty Unreleased). Consumer-facing upgrade notes are short and actionable.

Also in this PR:

- **Slider** — single thumb or range / N thumbs ([#106](https://github.com/corex-ui/corex/pull/106))
- Slider and angle-slider SSR `aria-value*`
- Zag.js / Phoenix / LiveView / Credo batch ([#118](https://github.com/corex-ui/corex/pull/118))
- `mix assets.build` clear error when nested `design/` Mix fails
- Hexdocs for `:corex` include `CHANGELOG.md`
- `mix corex.new --a11y` / `mix corex.tableau.new --a11y` print `corex_design: :load` for `mix release`

Does **not** Hex/npm-publish or git-tag. After merge: tag `v0.2.2` and publish each package.

## Test plan

- [x] `cd design && mix deps.get` then root `mix assets.build` — `Synced no-design export`
- [x] Root `mix test test/components/angle_slider_test.exs test/components/slider_test.exs` — 49 tests, 0 failures
- [x] `cd installer && mix test test/post_generate_test.exs test/tableau/post_generate_test.exs` — 23 tests, 0 failures
- [x] Root `mix docs` — `doc/changelog.html` builds with no warnings
- [x] `mix hex.audit` — no retired or advisory packages
- [x] CI green on prior head; changelog polish follow-up pushed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a939dd13-59ad-4695-8681-599b1390c54d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a939dd13-59ad-4695-8681-599b1390c54d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

